### PR TITLE
Ratio Converter and WPF Message Box bug

### DIFF
--- a/MessageBoxLibrary/WPFMessageBox.cs
+++ b/MessageBoxLibrary/WPFMessageBox.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 
 namespace MessageBoxLibrary
 {
@@ -332,6 +333,7 @@ namespace MessageBoxLibrary
             return ShowCore(owner, messageBoxText, caption, button, icon, defaultResult, options);
         }
 
+        [STAThread]
         private static MessageBoxResult ShowCore(
             Window owner,
             string messageBoxText,

--- a/W10 Logon BG Changer/MainWindow.xaml
+++ b/W10 Logon BG Changer/MainWindow.xaml
@@ -2,13 +2,16 @@
                       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                       xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
+                      xmlns:tools="clr-namespace:W10_Logon_BG_Changer.Tools"
                       ShowIconOnTitleBar="True"
                       GlowBrush="{DynamicResource AccentColorBrush}"
                       NonActiveGlowBrush="{DynamicResource AccentColorBrush2}"
                       BorderBrush="{DynamicResource AccentColorBrush}"
                       BorderThickness="1"
                       Background="Transparent"
-                      Title="W10 Logon BG Changer" Height="768" Width="1366"
+                      Title="W10 Logon BG Changer" 
+                      Height="{Binding Source={x:Static SystemParameters.PrimaryScreenHeight}, Converter={tools:RatioConverter}, ConverterParameter='0.9' }" 
+                      Width="{Binding Source={x:Static SystemParameters.PrimaryScreenWidth}, Converter={tools:RatioConverter}, ConverterParameter='0.9' }" 
                       MinHeight="500" MinWidth="830" WindowStartupLocation="CenterScreen">
 
     <controls:MetroWindow.LeftWindowCommands>

--- a/W10 Logon BG Changer/Tools/RatioConverter.cs
+++ b/W10 Logon BG Changer/Tools/RatioConverter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+using System.Windows.Markup;
+
+namespace W10_Logon_BG_Changer.Tools
+{
+    [ValueConversion(typeof(string), typeof(string))]
+    public class RatioConverter : MarkupExtension, IValueConverter
+    {
+        private static RatioConverter _instance;
+
+        public RatioConverter() { }
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            double size = System.Convert.ToDouble(value) * System.Convert.ToDouble(parameter, CultureInfo.InvariantCulture);
+            return size.ToString("G0", CultureInfo.InvariantCulture);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return _instance ?? (_instance = new RatioConverter());
+        }
+    }
+}

--- a/W10 Logon BG Changer/W10 Logon BG Changer.csproj
+++ b/W10 Logon BG Changer/W10 Logon BG Changer.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Properties\XamlItemsControlAttribute.cs" />
     <Compile Include="Tools\Animations\ControlFader.cs" />
     <Compile Include="Tools\AssemblyInfo.cs" />
+    <Compile Include="Tools\RatioConverter.cs" />
     <Compile Include="Tools\Customs\SerializableDictionary.cs" />
     <Compile Include="Tools\Helpers.cs" />
     <Compile Include="Tools\InlineExpression.cs" />


### PR DESCRIPTION
The ratio size was too big for my notebook with a lower resolution.
Given the fact that win 10 can even be executed on tablets, there should
be a ratio converter. The min size was maintained. Also, the message
boxes weren't being shown, because of the STA Thread not set. Fixed the
bug and added the enhancement.
