### PR TITLE
Fixed command line argument parsing

### DIFF
--- a/W10 Logon BG Changer - Command Line/Program.cs
+++ b/W10 Logon BG Changer - Command Line/Program.cs
@@ -23,7 +23,7 @@ namespace W10_Logon_BG_Changer___Command_Line
                 return;
             }
 
-            if (!args[0].ToLower().StartsWith("/") || !args[0].ToLower().StartsWith("-"))
+            if (!(args[0].ToLower().StartsWith("/") || args[0].ToLower().StartsWith("-")))
             {
                 Console.WriteLine("Please use '/h' for help");
                 return;


### PR DESCRIPTION
Currently the command line utility is not usable, because it wants the first argument to start with both '/' and '-' characters at the same time, which is impossible.
