### PR TITLE
Command Line refactoring

### DIFF
--- a/W10 Logon BG Changer - Command Line/Helpers/ImageHelper.cs
+++ b/W10 Logon BG Changer - Command Line/Helpers/ImageHelper.cs
@@ -1,0 +1,69 @@
+﻿using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using HelperLibrary;
+using SharedLibrary;
+
+namespace W10_Logon_BG_Changer___Command_Line.Helpers
+{
+    internal class ImageHelper
+    {
+        readonly string NewPriLocation = Path.Combine(Path.GetTempPath(), "new_temp_pri.pri");
+        readonly string TempPriFile = Path.Combine(Path.GetTempPath(), "bak_temp_pri.pri");
+
+        public void ChangeImage(string filedir)
+        {
+            File.Copy(Config.BakPriFileLocation, TempPriFile, true);
+            LogonPriEditor.ModifyLogonPri(TempPriFile, NewPriLocation, filedir);
+            File.Copy(NewPriLocation, Config.PriFileLocation, true);
+        }
+
+        public void Restore()
+        {
+            File.Copy(Config.BakPriFileLocation, Config.PriFileLocation, true);
+        }
+
+        private Bitmap DrawFilledRectangle(int x, int y, Brush b)
+        {
+            var bmp = new Bitmap(x, y);
+
+            using (var graph = Graphics.FromImage(bmp))
+            {
+                var imageSize = new Rectangle(0, 0, x, y);
+                graph.FillRectangle(b, imageSize);
+            }
+
+            return bmp;
+        }
+
+        public void ChangeColor(string hexColorCode)
+        {
+            Color color = (Color)new ColorConverter().ConvertFromString(hexColorCode);
+            string imagePath = Path.GetTempFileName();
+            DrawFilledRectangle(3840, 2160, new SolidBrush(color)).Save(imagePath, ImageFormat.Jpeg);
+            File.Copy(Config.BakPriFileLocation, TempPriFile, true);
+            LogonPriEditor.ModifyLogonPri(TempPriFile, NewPriLocation, imagePath);
+            File.Copy(NewPriLocation, Config.PriFileLocation, true);
+        }
+
+        public void TakeOwnership()
+        {
+            HelperLib.TakeOwnership(Config.LogonFolder);
+            HelperLib.TakeOwnership(Config.PriFileLocation);
+
+            if (!File.Exists(Config.BakPriFileLocation))
+            {
+                File.Copy(Config.PriFileLocation, Config.BakPriFileLocation);
+            }
+
+            HelperLib.TakeOwnership(Config.BakPriFileLocation);
+
+            File.Copy(Config.BakPriFileLocation, TempPriFile, true);
+
+            if (File.Exists(NewPriLocation))
+            {
+                File.Delete(NewPriLocation);
+            }
+        }
+    }
+}

--- a/W10 Logon BG Changer - Command Line/Helpers/MenuHelper.cs
+++ b/W10 Logon BG Changer - Command Line/Helpers/MenuHelper.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace W10_Logon_BG_Changer___Command_Line.Helpers
+{
+    internal class MenuHelper
+    {
+        public void ShowHelp()
+        {
+            Console.WriteLine();
+            Console.WriteLine("HELP");
+            Console.WriteLine("=====");
+            Console.WriteLine();
+            Console.WriteLine("AUTHORS - /A");
+            Console.WriteLine("COLOR - /C [HEX CODE]");
+            Console.WriteLine("IMAGE - /I [IMAGE PATH]");
+            Console.WriteLine("RESTORE - /R");
+            Console.WriteLine("HELP - /H");
+        }
+
+        public void ShowAuthors()
+        {
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine();
+            Console.WriteLine(@"Syrexide | https://github.com/Syrexide/");
+            Console.WriteLine(@"Toyz | https://github.com/Toyz/");
+            Console.ResetColor();
+        }
+
+        public void ShowSuccessMessage()
+        {
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine();
+            Console.WriteLine("Success!");
+            Console.ResetColor();
+        }
+    }
+}

--- a/W10 Logon BG Changer - Command Line/Helpers/ValidationHelper.cs
+++ b/W10 Logon BG Changer - Command Line/Helpers/ValidationHelper.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using SharedLibrary;
+
+namespace W10_Logon_BG_Changer___Command_Line.Helpers
+{
+    internal class ValidationHelper
+    {
+        public void ValidateImageArgument(string[] args)
+        {
+            if (args.Length < 2)
+                throw new ArgumentException("Usage: /i pathtoimage");
+
+            string filePath = args[1];
+
+            if (!File.Exists(filePath))
+                throw new FileNotFoundException(string.Format("An error occurred: The file \"{0}\" does not exist!", filePath));
+
+            var validExtensions = new List<string> { ".bmp", ".jpg", ".png", ".tif", ".tiff" };
+            string fileExtension = Path.GetExtension(filePath);
+
+            if (!validExtensions.Contains(fileExtension))
+                throw new ArgumentException(string.Format("An error occurred: The file \"{0}\" is not a valid file!", filePath));
+        }
+
+        public void ValidateColorArgument(string[] args)
+        {
+            if (args.Length < 2)
+                throw new ArgumentException("Usage: /c hexcode (Example: /c #000000)");
+
+            if (!args[1].IsHex())
+                throw new ArgumentException("Not a valid Hex color!");
+        }
+
+        public void ValidateFirstArgument(string[] args)
+        {
+            const string message = "Please use '/h' for help";
+
+            if (args.Length <= 0)
+                throw new ArgumentException(message);
+
+            string firstArgument = args[0].ToLower();
+
+            if (!(firstArgument.StartsWith("/") || firstArgument.StartsWith("-")))
+                throw new ArgumentException(message);
+        }
+    }
+}

--- a/W10 Logon BG Changer - Command Line/Program.cs
+++ b/W10 Logon BG Changer - Command Line/Program.cs
@@ -1,193 +1,50 @@
-﻿using HelperLibrary;
-using SharedLibrary;
-using System;
-using System.Drawing;
-using System.Drawing.Imaging;
-using System.IO;
+﻿using System;
+using W10_Logon_BG_Changer___Command_Line.Helpers;
 
 namespace W10_Logon_BG_Changer___Command_Line
 {
     internal class Program
     {
-        private static readonly string NewPriLocation = Path.Combine(Path.GetTempPath(), "new_temp_pri.pri");
-        private static readonly string TempPriFile = Path.Combine(Path.GetTempPath(), "bak_temp_pri.pri");
-
         private static void Main(string[] args)
         {
-            TakeOwnership();
+            var imageHelper = new ImageHelper();
+            var validator = new ValidationHelper();
+            var menuHelper = new MenuHelper();
 
-
-            if (args.Length <= 0)
+            try
             {
-                Console.WriteLine("Please use '/h' for help");
-                return;
+                imageHelper.TakeOwnership();
+                validator.ValidateFirstArgument(args);
+                string firstArgument = args[0].ToLower().Replace("/", "").Replace("-", "");
+
+                switch (firstArgument)
+                {
+                    case "h":
+                        menuHelper.ShowHelp();
+                        break;
+                    case "a":
+                        menuHelper.ShowAuthors();
+                        break;
+                    case "c":
+                        validator.ValidateColorArgument(args);
+                        imageHelper.ChangeColor(args[1]);
+                        break;
+                    case "i":
+                        validator.ValidateImageArgument(args);
+                        imageHelper.ChangeImage(args[1]);
+                        menuHelper.ShowSuccessMessage();
+                        break;
+                    case "r":
+                        imageHelper.Restore();
+                        menuHelper.ShowSuccessMessage();
+                        break;
+                    default:
+                        throw new ArgumentException("Please use '/h' for help");
+                }
             }
-
-            if (!(args[0].ToLower().StartsWith("/") || args[0].ToLower().StartsWith("-")))
+            catch (Exception ex)
             {
-                Console.WriteLine("Please use '/h' for help");
-                return;
-            }
-
-            switch (args[0].ToLower().Replace("/", "").Replace("-", ""))
-            {
-                case "h":
-                    Console.WriteLine("");
-                    Console.WriteLine("HELP");
-                    Console.WriteLine("=====");
-                    Console.WriteLine("");
-                    Console.WriteLine("AUTHORS - /A");
-                    Console.WriteLine("COLOR - /C [HEX CODE]");
-                    Console.WriteLine("IMAGE - /I [IMAGE PATH]");
-                    Console.WriteLine("RESTORE - /R");
-                    Console.WriteLine("HELP - /H");
-                    break;
-
-                case "a":
-                    Console.ForegroundColor = ConsoleColor.Green;
-                    Console.WriteLine("");
-                    Console.WriteLine(@"Syrexide | https://github.com/Syrexide/");
-                    Console.WriteLine(@"Toyz | https://github.com/Toyz/");
-                    Console.ResetColor();
-                    break;
-
-                case "c":
-                    if (args.Length < 2)
-                    {
-                        Console.WriteLine("Usage: /c hexcode (Example /c 000000");
-                        return;
-                    }
-
-                    var hex = args[1];
-
-                    if (!hex.IsHex())
-                    {
-                        Console.WriteLine("Not a valid Hex color!");
-                        return;
-                    }
-
-                    var converter = new ColorConverter();
-                    var convertFromString = converter.ConvertFromString(hex);
-
-                    if(convertFromString != null)
-                        ChangeColor((Color)convertFromString);
-                    break;
-
-                case "i":
-                    if (args.Length < 2)
-                    {
-                        Console.WriteLine("Usage: /i pathtoimage");
-                        return;
-                    }
-
-                    var filedir = args[1];
-
-                    if (File.Exists(filedir) && (Path.GetExtension(filedir) == ".jpg") ||
-                                (Path.GetExtension(filedir) == ".png") || (Path.GetExtension(filedir) == ".bmp") ||
-                                (Path.GetExtension(filedir) == ".tif") || (Path.GetExtension(filedir) == ".tiff"))
-                    {
-                        ChangeImage(filedir);
-                        Console.ForegroundColor = ConsoleColor.Green;
-                        Console.WriteLine("");
-                        Console.WriteLine("Success!");
-                        Console.ResetColor();
-                    }
-                    else
-                    {
-                        Console.ForegroundColor = ConsoleColor.Red;
-                        Console.WriteLine("");
-                        Console.WriteLine("An error occurred: The file \"{0}\" is not a valid file!", filedir);
-                        Console.ResetColor();
-                    }
-                    break;
-
-                case "r":
-                    try
-                    {
-                        Restore();
-                        Console.ForegroundColor = ConsoleColor.Green;
-                        Console.WriteLine("");
-                        Console.WriteLine("Success!");
-                        Console.ResetColor();
-                    }
-                    catch (Exception e)
-                    {
-                        Console.ForegroundColor = ConsoleColor.Red;
-                        Console.WriteLine("");
-                        Console.WriteLine(@"An error occurred: '{0}'", e);
-                        Console.ResetColor();
-                    }
-                    return;
-
-                default:
-                    Console.WriteLine("Please use '/h' for help");
-                    return;
-            }
-        }
-
-        private static void ChangeImage(string filedir)
-        {
-            File.Copy(Config.BakPriFileLocation, TempPriFile, true);
-
-            LogonPriEditor.ModifyLogonPri(TempPriFile, NewPriLocation, filedir);
-
-            File.Copy(NewPriLocation, Config.PriFileLocation, true);
-        }
-
-        private static void Restore()
-        {
-            File.Copy(Config.BakPriFileLocation, Config.PriFileLocation, true);
-        }
-
-        private static string FillImageColor(Color c)
-        {
-            var image = Path.GetTempFileName();
-
-            DrawFilledRectangle(3840, 2160, new SolidBrush(c)).Save(image, ImageFormat.Jpeg);
-
-            return image;
-        }
-
-        private static Bitmap DrawFilledRectangle(int x, int y, Brush b)
-        {
-            var bmp = new Bitmap(x, y);
-            using (var graph = Graphics.FromImage(bmp))
-            {
-                var imageSize = new Rectangle(0, 0, x, y);
-                graph.FillRectangle(b, imageSize);
-            }
-            return bmp;
-        }
-
-        private static void ChangeColor(Color c)
-        {
-            var image = FillImageColor(c);
-
-            File.Copy(Config.BakPriFileLocation, TempPriFile, true);
-
-            LogonPriEditor.ModifyLogonPri(TempPriFile, NewPriLocation, image);
-
-            File.Copy(NewPriLocation, Config.PriFileLocation, true);
-        }
-
-        private static void TakeOwnership()
-        {
-            HelperLib.TakeOwnership(Config.LogonFolder);
-
-            HelperLib.TakeOwnership(Config.PriFileLocation);
-
-            if (!File.Exists(Config.BakPriFileLocation))
-            {
-                File.Copy(Config.PriFileLocation, Config.BakPriFileLocation);
-            }
-
-            HelperLib.TakeOwnership(Config.BakPriFileLocation);
-
-            File.Copy(Config.BakPriFileLocation, TempPriFile, true);
-
-            if (File.Exists(NewPriLocation))
-            {
-                File.Delete(NewPriLocation);
+                Console.WriteLine(ex.Message);
             }
         }
     }

--- a/W10 Logon BG Changer - Command Line/W10 Logon BG Changer - Command Line.csproj
+++ b/W10 Logon BG Changer - Command Line/W10 Logon BG Changer - Command Line.csproj
@@ -44,6 +44,9 @@
     <Reference Include="System.Drawing" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Helpers\ImageHelper.cs" />
+    <Compile Include="Helpers\MenuHelper.cs" />
+    <Compile Include="Helpers\ValidationHelper.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -61,6 +64,7 @@
       <Name>SharedLibrary</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Hey Toyz,

I've applied some refactorings to the Command Line utility. Now the code should be easier to read and maintain.

1) Modified the text "Usage: /c hexcode (Example /c 000000" to "Usage: /c hexcode (Example: /c #000000)";
2) Replaced Console.WriteLine("") with Console.WriteLine();
3) Grouped all helper methods into three classes: ImageHelper, ValidationHelper and MenuHelper;
4) Merged FillImageColor and ChangeColor methods;
5) Changed ChangeColor method parameter from "Color c" to "string hexColorCode";
6) Moved NewPriLocation and TempPriFile fields into ImageHelper class;
7) Replaced writing error messages to console with throwing exceptions.
